### PR TITLE
correcting 'catatlog' plugin spelling error

### DIFF
--- a/galasa-maven-plugin/pom.xml
+++ b/galasa-maven-plugin/pom.xml
@@ -148,6 +148,12 @@
 			<artifactId>gson</artifactId>
 			<version>2.8.5</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>3.25.3</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/galasa-maven-plugin/pom.xml
+++ b/galasa-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>dev.galasa</groupId>
 	<artifactId>galasa-maven-plugin</artifactId>
-	<version>0.29.0</version>
+	<version>0.32.0</version>
 	<packaging>maven-plugin</packaging>
 
 	<name>Galasa Maven Plugin</name>
@@ -91,9 +91,9 @@
 			<version>3.6.2</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-core</artifactId>
-			<version>3.6.2</version>
+			<groupId>org.apache.maven.shared</groupId>
+			<artifactId>maven-shared-utils</artifactId>
+			<version>3.4.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/BuildBundleTestCatalog.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/BuildBundleTestCatalog.java
@@ -69,7 +69,7 @@ public class BuildBundleTestCatalog extends AbstractMojo {
     @Parameter(defaultValue = "${galasa.skip.bundletestcatalog}", readonly = true, required = false)
     private boolean            correctSkip;
     
-    private boolean skip = DeployTestCatalog.setSkip(correctSkip, typoSkip);
+    private boolean skip = DeployTestCatalog.setCorrectBooleanValue(correctSkip, typoSkip);
 
     public void execute() throws MojoExecutionException, MojoFailureException {
         

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/BuildBundleTestCatalog.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/BuildBundleTestCatalog.java
@@ -63,18 +63,16 @@ public class BuildBundleTestCatalog extends AbstractMojo {
     @Parameter(defaultValue = "${project.compileClasspathElements}", readonly = true, required = true)
     private List<String>       classpathElements;
 
-    private boolean skip;
-
     @Parameter(defaultValue = "${galasa.skip.bundletestcatatlog}", readonly = true, required = false)
     private boolean            typoSkip;
-
+    
     @Parameter(defaultValue = "${galasa.skip.bundletestcatalog}", readonly = true, required = false)
     private boolean            correctSkip;
+    
+    private boolean skip = DeployTestCatalog.setSkip(correctSkip, typoSkip);
 
     public void execute() throws MojoExecutionException, MojoFailureException {
         
-        skip = DeployTestCatalog.setSkip(correctSkip, typoSkip);
-
         if (skip) {
             getLog().info("Skipping Bundle Test Catalog build");
             return;

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/BuildBundleTestCatalog.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/BuildBundleTestCatalog.java
@@ -63,10 +63,17 @@ public class BuildBundleTestCatalog extends AbstractMojo {
     @Parameter(defaultValue = "${project.compileClasspathElements}", readonly = true, required = true)
     private List<String>       classpathElements;
 
+    private boolean skip;
+
     @Parameter(defaultValue = "${galasa.skip.bundletestcatatlog}", readonly = true, required = false)
-    private boolean            skip;
+    private boolean            typoSkip;
+
+    @Parameter(defaultValue = "${galasa.skip.bundletestcatalog}", readonly = true, required = false)
+    private boolean            correctSkip;
 
     public void execute() throws MojoExecutionException, MojoFailureException {
+        
+        skip = DeployTestCatalog.setSkip(correctSkip, typoSkip);
 
         if (skip) {
             getLog().info("Skipping Bundle Test Catalog build");

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/BuildGherkinTestCatalog.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/BuildGherkinTestCatalog.java
@@ -46,7 +46,7 @@ public class BuildGherkinTestCatalog extends AbstractMojo {
     @Parameter(defaultValue = "${galasa.skip.gherkintestcatalog}", readonly = true, required = false)
     private boolean            correctSkip;
     
-    private boolean skip = DeployTestCatalog.setSkip(correctSkip, typoSkip);
+    private boolean skip = DeployTestCatalog.setCorrectBooleanValue(correctSkip, typoSkip);
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/BuildGherkinTestCatalog.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/BuildGherkinTestCatalog.java
@@ -39,9 +39,14 @@ public class BuildGherkinTestCatalog extends AbstractMojo {
 
     @Parameter(defaultValue = "${project.build.directory}", property = "outputDir", required = true)
     private File               outputDirectory;
-
+    
     @Parameter(defaultValue = "${galasa.skip.gherkintestcatatlog}", readonly = true, required = false)
-    private boolean            skip;
+    private boolean            typoSkip;
+    
+    @Parameter(defaultValue = "${galasa.skip.gherkintestcatalog}", readonly = true, required = false)
+    private boolean            correctSkip;
+    
+    private boolean skip = DeployTestCatalog.setSkip(correctSkip, typoSkip);
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/DeployTestCatalog.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/DeployTestCatalog.java
@@ -33,37 +33,42 @@ public class DeployTestCatalog extends AbstractMojo {
     @Parameter(defaultValue = "${project}", readonly = true)
     private MavenProject project;
 
-
-    @Parameter(defaultValue = "${galasa.skip.deploytestcatatlog}", readonly = true, required = false)
-    private boolean      skipDeploy;
-
     @Parameter(defaultValue = "${galasa.test.stream}", readonly = true, required = false)
     private String       testStream;
 
     @Parameter(defaultValue = "${galasa.bootstrap}", readonly = true, required = false)
     private URL          bootstrapUrl;
 
-    protected boolean      skip;
+    private boolean      skip;
+    private boolean      skipDeploy;
 
     @Parameter(defaultValue = "${galasa.skip.bundletestcatalog}", readonly = true, required = false)
-    protected boolean      typoSkip;
+    private boolean      typoSkip;
 
     @Parameter(defaultValue = "${galasa.skip.bundletestcatalog}", readonly = true, required = false)
-    protected boolean      correctSkip;
+    private boolean      correctSkip;
 
-    protected void setSkip() {
+    @Parameter(defaultValue = "${galasa.skip.deploytestcatatlog}", readonly = true, required = false)
+    private boolean      typoSkipDeploy;
+
+    @Parameter(defaultValue = "${galasa.skip.deploytestcatalog}", readonly = true, required = false)
+    private boolean      correctSkipDeploy;
+
+
+    protected boolean setSkip(boolean correctSkip, boolean typoSkip) {
+        boolean skip = false;
         //boolean default value is false
         if (correctSkip || typoSkip) {
             //if one of the skip variables is set, we know for sure to skip
             skip = true;
-        } else {
-            skip = false;
-        }
+        } 
+        return skip;
     }
 
     public void execute() throws MojoExecutionException, MojoFailureException {
 
-        setSkip();
+        skip = setSkip(correctSkip, typoSkip);
+        skipDeploy = setSkip(correctSkip, typoSkip);
         
         if (skip || skipDeploy) {
             getLog().info("Skipping Deploy Test Catalog");

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/DeployTestCatalog.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/DeployTestCatalog.java
@@ -33,8 +33,6 @@ public class DeployTestCatalog extends AbstractMojo {
     @Parameter(defaultValue = "${project}", readonly = true)
     private MavenProject project;
 
-    @Parameter(defaultValue = "${galasa.skip.bundletestcatatlog}", readonly = true, required = false)
-    private boolean      skip;
 
     @Parameter(defaultValue = "${galasa.skip.deploytestcatatlog}", readonly = true, required = false)
     private boolean      skipDeploy;
@@ -45,8 +43,28 @@ public class DeployTestCatalog extends AbstractMojo {
     @Parameter(defaultValue = "${galasa.bootstrap}", readonly = true, required = false)
     private URL          bootstrapUrl;
 
+    protected boolean      skip;
+
+    @Parameter(defaultValue = "${galasa.skip.bundletestcatalog}", readonly = true, required = false)
+    protected boolean      typoSkip;
+
+    @Parameter(defaultValue = "${galasa.skip.bundletestcatalog}", readonly = true, required = false)
+    protected boolean      correctSkip;
+
+    protected void setSkip() {
+        //boolean default value is false
+        if (correctSkip || typoSkip) {
+            //if one of the skip variables is set, we know for sure to skip
+            skip = true;
+        } else {
+            skip = false;
+        }
+    }
+
     public void execute() throws MojoExecutionException, MojoFailureException {
 
+        setSkip();
+        
         if (skip || skipDeploy) {
             getLog().info("Skipping Deploy Test Catalog");
             return;

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/DeployTestCatalog.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/DeployTestCatalog.java
@@ -55,7 +55,7 @@ public class DeployTestCatalog extends AbstractMojo {
     private boolean      correctSkipDeploy;
 
 
-    protected boolean setSkip(boolean correctSkip, boolean typoSkip) {
+    protected static boolean setSkip(boolean correctSkip, boolean typoSkip) {
         boolean skip = false;
         //boolean default value is false
         if (correctSkip || typoSkip) {

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/DeployTestCatalog.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/DeployTestCatalog.java
@@ -52,10 +52,10 @@ public class DeployTestCatalog extends AbstractMojo {
     @Parameter(defaultValue = "${galasa.skip.deploytestcatalog}", readonly = true, required = false)
     private boolean      correctSkipDeploy;
     
-    private boolean      skip = setSkip(correctSkip, typoSkip);
-    private boolean      skipDeploy = setSkip(correctSkip, typoSkip);
+    private boolean      skip = setCorrectBooleanValue(correctSkip, typoSkip);
+    private boolean      skipDeploy = setCorrectBooleanValue(correctSkipDeploy, typoSkipDeploy);
 
-    protected static boolean setSkip(boolean correctSkip, boolean typoSkip) {
+    protected static boolean setCorrectBooleanValue(boolean correctSkip, boolean typoSkip) {
         boolean skip = false;
         //boolean default value is false
         if (correctSkip || typoSkip) {

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/DeployTestCatalog.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/DeployTestCatalog.java
@@ -39,21 +39,21 @@ public class DeployTestCatalog extends AbstractMojo {
     @Parameter(defaultValue = "${galasa.bootstrap}", readonly = true, required = false)
     private URL          bootstrapUrl;
 
-    private boolean      skip;
-    private boolean      skipDeploy;
-
-    @Parameter(defaultValue = "${galasa.skip.bundletestcatalog}", readonly = true, required = false)
+    
+    @Parameter(defaultValue = "${galasa.skip.bundletestcatatlog}", readonly = true, required = false)
     private boolean      typoSkip;
-
+    
     @Parameter(defaultValue = "${galasa.skip.bundletestcatalog}", readonly = true, required = false)
     private boolean      correctSkip;
-
+    
     @Parameter(defaultValue = "${galasa.skip.deploytestcatatlog}", readonly = true, required = false)
     private boolean      typoSkipDeploy;
-
+    
     @Parameter(defaultValue = "${galasa.skip.deploytestcatalog}", readonly = true, required = false)
     private boolean      correctSkipDeploy;
-
+    
+    private boolean      skip = setSkip(correctSkip, typoSkip);
+    private boolean      skipDeploy = setSkip(correctSkip, typoSkip);
 
     protected static boolean setSkip(boolean correctSkip, boolean typoSkip) {
         boolean skip = false;
@@ -67,9 +67,6 @@ public class DeployTestCatalog extends AbstractMojo {
 
     public void execute() throws MojoExecutionException, MojoFailureException {
 
-        skip = setSkip(correctSkip, typoSkip);
-        skipDeploy = setSkip(correctSkip, typoSkip);
-        
         if (skip || skipDeploy) {
             getLog().info("Skipping Deploy Test Catalog");
             return;

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/MergeTestCatalogs.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/MergeTestCatalogs.java
@@ -62,9 +62,14 @@ public class MergeTestCatalogs extends AbstractMojo {
 
     @Parameter(defaultValue = "${project.build.directory}", property = "outputDir", required = true)
     private File                    outputDirectory;
-
+    
     @Parameter(defaultValue = "${galasa.skip.bundletestcatatlog}", readonly = true, required = false)
-    private boolean                 skip;
+    private boolean                 typoSkip;
+    
+    @Parameter(defaultValue = "${galasa.skip.bundletestcatalog}", readonly = true, required = false)
+    private boolean                 correctSkip;
+    
+    private boolean skip = DeployTestCatalog.setSkip(correctSkip, typoSkip);
 
     @Parameter(defaultValue = "${galasa.build.job}", readonly = true, required = false)
     private String                  buildJob;

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/MergeTestCatalogs.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/MergeTestCatalogs.java
@@ -69,7 +69,7 @@ public class MergeTestCatalogs extends AbstractMojo {
     @Parameter(defaultValue = "${galasa.skip.bundletestcatalog}", readonly = true, required = false)
     private boolean                 correctSkip;
     
-    private boolean skip = DeployTestCatalog.setSkip(correctSkip, typoSkip);
+    private boolean skip = DeployTestCatalog.setCorrectBooleanValue(correctSkip, typoSkip);
 
     @Parameter(defaultValue = "${galasa.build.job}", readonly = true, required = false)
     private String                  buildJob;

--- a/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/DeployTestCatalogTest.java
+++ b/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/DeployTestCatalogTest.java
@@ -13,49 +13,18 @@ import org.junit.Test;
 
 public class DeployTestCatalogTest {
 
-    private class MockDeployTestCatalog extends DeployTestCatalog{
-
-        public boolean getSkip(){
-            return super.skip;
-        }
-
-        public boolean getTypoSkip() {
-            return super.typoSkip;
-        }
-
-        public boolean getCorrectSkip() {
-            return super.correctSkip;
-        }
-
-        private void setUp(boolean typo, boolean correct){
-            setTypoSkip(this.typoSkip, typo);
-            setCorrectSkip(this.correctSkip, correct);
-        }
-
-        private void setTypoSkip(boolean typoSkip, boolean typo) {
-            super.typoSkip = typo;
-        }
-        private void setCorrectSkip(boolean correctSkip, boolean correct) {
-            super.correctSkip = correct;
-        }
-    
-    }
-
     @Test
     public void setSkipTrueWhenTypoSkipIsTrue() {
         //Given...
         boolean typoSkip = true;
         boolean correctSkip = false;
-        MockDeployTestCatalog deployTest = new MockDeployTestCatalog();
-        deployTest.setUp(typoSkip, correctSkip);
+        DeployTestCatalog deployTest = new DeployTestCatalog();
         
         //When...
-        deployTest.setSkip();
+        boolean skipResult = deployTest.setSkip(correctSkip, typoSkip);
 
         //Then...
-        assertThat(deployTest.getTypoSkip()).isTrue();
-        assertThat(deployTest.getCorrectSkip()).isFalse();
-        assertThat(deployTest.getSkip()).isTrue();
+        assertThat(skipResult).isTrue();
     }
 
     @Test
@@ -63,16 +32,13 @@ public class DeployTestCatalogTest {
         //Given...
         boolean typoSkip = false;
         boolean correctSkip = false;
-        MockDeployTestCatalog deployTest = new MockDeployTestCatalog();
-        deployTest.setUp(typoSkip, correctSkip);
+        DeployTestCatalog deployTest = new DeployTestCatalog();
         
         //When...
-        deployTest.setSkip();
+        boolean skipResult = deployTest.setSkip(correctSkip, typoSkip);
 
         //Then...
-        assertThat(deployTest.getTypoSkip()).isFalse();
-        assertThat(deployTest.getCorrectSkip()).isFalse();
-        assertThat(deployTest.getSkip()).isFalse();
+        assertThat(skipResult).isFalse();
     }
 
 
@@ -81,16 +47,13 @@ public class DeployTestCatalogTest {
         //Given...
         boolean typoSkip = false;
         boolean correctSkip = true;
-        MockDeployTestCatalog deployTest = new MockDeployTestCatalog();
-        deployTest.setUp(typoSkip, correctSkip);
+        DeployTestCatalog deployTest = new DeployTestCatalog();
         
         //When...
-        deployTest.setSkip();
+        boolean skipResult = deployTest.setSkip(correctSkip, typoSkip);
 
         //Then...
-        assertThat(deployTest.getTypoSkip()).isFalse();
-        assertThat(deployTest.getCorrectSkip()).isTrue();
-        assertThat(deployTest.getSkip()).isTrue();
+        assertThat(skipResult).isTrue();
     }
 
     @Test
@@ -98,16 +61,13 @@ public class DeployTestCatalogTest {
         //Given...
         boolean typoSkip = true;
         boolean correctSkip = true;
-        MockDeployTestCatalog deployTest = new MockDeployTestCatalog();
-        deployTest.setUp(typoSkip, correctSkip);
+        DeployTestCatalog deployTest = new DeployTestCatalog();
         
         //When...
-        deployTest.setSkip();
+        boolean skipResult = deployTest.setSkip(correctSkip, typoSkip);
 
         //Then...
-        assertThat(deployTest.getTypoSkip()).isTrue();
-        assertThat(deployTest.getCorrectSkip()).isTrue();
-        assertThat(deployTest.getSkip()).isTrue();
+        assertThat(skipResult).isTrue();
     }
 
 }

--- a/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/DeployTestCatalogTest.java
+++ b/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/DeployTestCatalogTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package dev.galasa.maven.plugin;
+import static org.assertj.core.api.Assertions.*;
+
+
+import org.junit.Test;
+
+
+public class DeployTestCatalogTest {
+
+    private class MockDeployTestCatalog extends DeployTestCatalog{
+
+        public boolean getSkip(){
+            return super.skip;
+        }
+
+        public boolean getTypoSkip() {
+            return super.typoSkip;
+        }
+
+        public boolean getCorrectSkip() {
+            return super.correctSkip;
+        }
+
+        private void setUp(boolean typo, boolean correct){
+            setTypoSkip(this.typoSkip, typo);
+            setCorrectSkip(this.correctSkip, correct);
+        }
+
+        private void setTypoSkip(boolean typoSkip, boolean typo) {
+            super.typoSkip = typo;
+        }
+        private void setCorrectSkip(boolean correctSkip, boolean correct) {
+            super.correctSkip = correct;
+        }
+    
+    }
+
+    @Test
+    public void setSkipTrueWhenTypoSkipIsTrue() {
+        //Given...
+        boolean typoSkip = true;
+        boolean correctSkip = false;
+        MockDeployTestCatalog deployTest = new MockDeployTestCatalog();
+        deployTest.setUp(typoSkip, correctSkip);
+        
+        //When...
+        deployTest.setSkip();
+
+        //Then...
+        assertThat(deployTest.getTypoSkip()).isTrue();
+        assertThat(deployTest.getCorrectSkip()).isFalse();
+        assertThat(deployTest.getSkip()).isTrue();
+    }
+
+    @Test
+    public void setSkipFalseWhenTypoSkipAndCorrectSkipIsFalse() {
+        //Given...
+        boolean typoSkip = false;
+        boolean correctSkip = false;
+        MockDeployTestCatalog deployTest = new MockDeployTestCatalog();
+        deployTest.setUp(typoSkip, correctSkip);
+        
+        //When...
+        deployTest.setSkip();
+
+        //Then...
+        assertThat(deployTest.getTypoSkip()).isFalse();
+        assertThat(deployTest.getCorrectSkip()).isFalse();
+        assertThat(deployTest.getSkip()).isFalse();
+    }
+
+
+    @Test
+    public void setSkipTrueWhenCorrectSkipIsTrue() {
+        //Given...
+        boolean typoSkip = false;
+        boolean correctSkip = true;
+        MockDeployTestCatalog deployTest = new MockDeployTestCatalog();
+        deployTest.setUp(typoSkip, correctSkip);
+        
+        //When...
+        deployTest.setSkip();
+
+        //Then...
+        assertThat(deployTest.getTypoSkip()).isFalse();
+        assertThat(deployTest.getCorrectSkip()).isTrue();
+        assertThat(deployTest.getSkip()).isTrue();
+    }
+
+    @Test
+    public void setSkipTrueWhenCorrectSkipAndTypoSkipIsTrue() {
+        //Given...
+        boolean typoSkip = true;
+        boolean correctSkip = true;
+        MockDeployTestCatalog deployTest = new MockDeployTestCatalog();
+        deployTest.setUp(typoSkip, correctSkip);
+        
+        //When...
+        deployTest.setSkip();
+
+        //Then...
+        assertThat(deployTest.getTypoSkip()).isTrue();
+        assertThat(deployTest.getCorrectSkip()).isTrue();
+        assertThat(deployTest.getSkip()).isTrue();
+    }
+
+}

--- a/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/DeployTestCatalogTest.java
+++ b/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/DeployTestCatalogTest.java
@@ -18,10 +18,9 @@ public class DeployTestCatalogTest {
         //Given...
         boolean typoSkip = true;
         boolean correctSkip = false;
-        DeployTestCatalog deployTest = new DeployTestCatalog();
         
         //When...
-        boolean skipResult = deployTest.setSkip(correctSkip, typoSkip);
+        boolean skipResult = DeployTestCatalog.setSkip(correctSkip, typoSkip);
 
         //Then...
         assertThat(skipResult).isTrue();
@@ -32,10 +31,9 @@ public class DeployTestCatalogTest {
         //Given...
         boolean typoSkip = false;
         boolean correctSkip = false;
-        DeployTestCatalog deployTest = new DeployTestCatalog();
         
         //When...
-        boolean skipResult = deployTest.setSkip(correctSkip, typoSkip);
+        boolean skipResult = DeployTestCatalog.setSkip(correctSkip, typoSkip);
 
         //Then...
         assertThat(skipResult).isFalse();
@@ -47,10 +45,9 @@ public class DeployTestCatalogTest {
         //Given...
         boolean typoSkip = false;
         boolean correctSkip = true;
-        DeployTestCatalog deployTest = new DeployTestCatalog();
         
         //When...
-        boolean skipResult = deployTest.setSkip(correctSkip, typoSkip);
+        boolean skipResult = DeployTestCatalog.setSkip(correctSkip, typoSkip);
 
         //Then...
         assertThat(skipResult).isTrue();
@@ -61,10 +58,9 @@ public class DeployTestCatalogTest {
         //Given...
         boolean typoSkip = true;
         boolean correctSkip = true;
-        DeployTestCatalog deployTest = new DeployTestCatalog();
         
         //When...
-        boolean skipResult = deployTest.setSkip(correctSkip, typoSkip);
+        boolean skipResult = DeployTestCatalog.setSkip(correctSkip, typoSkip);
 
         //Then...
         assertThat(skipResult).isTrue();

--- a/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/DeployTestCatalogTest.java
+++ b/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/DeployTestCatalogTest.java
@@ -14,26 +14,26 @@ import org.junit.Test;
 public class DeployTestCatalogTest {
 
     @Test
-    public void setSkipTrueWhenTypoSkipIsTrue() {
+    public void setCorrectBooleanValueTrueWhenTypoSkipIsTrue() {
         //Given...
         boolean typoSkip = true;
         boolean correctSkip = false;
         
         //When...
-        boolean skipResult = DeployTestCatalog.setSkip(correctSkip, typoSkip);
+        boolean skipResult = DeployTestCatalog.setCorrectBooleanValue(correctSkip, typoSkip);
 
         //Then...
         assertThat(skipResult).isTrue();
     }
 
     @Test
-    public void setSkipFalseWhenTypoSkipAndCorrectSkipIsFalse() {
+    public void setCorrectBooleanValueFalseWhenTypoSkipAndCorrectSkipIsFalse() {
         //Given...
         boolean typoSkip = false;
         boolean correctSkip = false;
         
         //When...
-        boolean skipResult = DeployTestCatalog.setSkip(correctSkip, typoSkip);
+        boolean skipResult = DeployTestCatalog.setCorrectBooleanValue(correctSkip, typoSkip);
 
         //Then...
         assertThat(skipResult).isFalse();
@@ -41,26 +41,26 @@ public class DeployTestCatalogTest {
 
 
     @Test
-    public void setSkipTrueWhenCorrectSkipIsTrue() {
+    public void setCorrectBooleanValueTrueWhenCorrectSkipIsTrue() {
         //Given...
         boolean typoSkip = false;
         boolean correctSkip = true;
         
         //When...
-        boolean skipResult = DeployTestCatalog.setSkip(correctSkip, typoSkip);
+        boolean skipResult = DeployTestCatalog.setCorrectBooleanValue(correctSkip, typoSkip);
 
         //Then...
         assertThat(skipResult).isTrue();
     }
 
     @Test
-    public void setSkipTrueWhenCorrectSkipAndTypoSkipIsTrue() {
+    public void setCorrectBooleanValueTrueWhenCorrectSkipAndTypoSkipIsTrue() {
         //Given...
         boolean typoSkip = true;
         boolean correctSkip = true;
         
         //When...
-        boolean skipResult = DeployTestCatalog.setSkip(correctSkip, typoSkip);
+        boolean skipResult = DeployTestCatalog.setCorrectBooleanValue(correctSkip, typoSkip);
 
         //Then...
         assertThat(skipResult).isTrue();


### PR DESCRIPTION
Story: https://github.com/galasa-dev/projectmanagement/issues/1755