### PR TITLE
Replace maven-core with maven-shared-utils to fix vulnerability

### DIFF
--- a/galasa-maven-plugin/pom.xml
+++ b/galasa-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>dev.galasa</groupId>
 	<artifactId>galasa-maven-plugin</artifactId>
-	<version>0.29.0</version>
+	<version>0.32.0</version>
 	<packaging>maven-plugin</packaging>
 
 	<name>Galasa Maven Plugin</name>

--- a/galasa-maven-plugin/pom.xml
+++ b/galasa-maven-plugin/pom.xml
@@ -91,9 +91,9 @@
 			<version>3.6.2</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-core</artifactId>
-			<version>3.6.2</version>
+			<groupId>org.apache.maven.shared</groupId>
+			<artifactId>maven-shared-utils</artifactId>
+			<version>3.4.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1741

- Replace maven-core v3.6.2 with maven-shared-utils v3.4.2 to resolve the existing critical vulnerability in the maven plugin
- Bumped the maven plugin to 0.32.0