### PR TITLE
Bump maven-compat to 3.9.6

### DIFF
--- a/galasa-maven-plugin/pom.xml
+++ b/galasa-maven-plugin/pom.xml
@@ -104,7 +104,7 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-compat</artifactId>
-			<version>3.6.2</version>
+			<version>3.9.6</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
Related to Snyk report in https://github.com/galasa-dev/projectmanagement/issues/1741

Resolves high severity vulnerabilities from the maven-compat dependency by bumping maven-compat to 3.9.6 - see https://mvnrepository.com/artifact/org.apache.maven/maven-compat/3.9.6
