### PR TITLE
Improving logging to find cause of error

### DIFF
--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/DeployTestCatalog.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/DeployTestCatalog.java
@@ -38,7 +38,6 @@ public class DeployTestCatalog extends AbstractMojo {
 
     @Parameter(defaultValue = "${galasa.bootstrap}", readonly = true, required = false)
     private URL          bootstrapUrl;
-
     
     @Parameter(defaultValue = "${galasa.skip.bundletestcatatlog}", readonly = true, required = false)
     private boolean      typoSkip;
@@ -75,6 +74,7 @@ public class DeployTestCatalog extends AbstractMojo {
     }
 
     public void execute() throws MojoExecutionException, MojoFailureException {
+        getLog().info("DeployTestCatalog - execute()");
 
         if (skip || skipDeploy) {
             getLog().info("Skipping Deploy Test Catalog");
@@ -113,7 +113,9 @@ public class DeployTestCatalog extends AbstractMojo {
             Properties bootstrapProperties = new Properties();
             try {
                 URLConnection connection = bootstrapUrl.openConnection();
+                getLog().info("URLConnection: " + connection);
                 bootstrapProperties.load(connection.getInputStream());
+                getLog().info("bootstrapProperties loaded: " + bootstrapProperties);
             } catch (Exception e) {
                 throw new MojoExecutionException("Unable to load the bootstrap properties", e);
             }


### PR DESCRIPTION
Signed-off-by: Fiona Ampofo <64271621+Akyiaa@users.noreply.github.com>

After subsequent changes in : https://github.com/galasa-dev/integratedtests/pull/191
The correct plugin spelling was used in integratedtests repo: https://github.com/galasa-dev/integratedtests/pull/191
 The pr build passed, but the build after it was merged in main failed. Seems to be some certification issues, not to do with the plugin changes. So I am adding some loggings to try and find the root cause of the build fail