### PR TITLE
publish test catalog to github now requires a galasa.token for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,168 @@ Environment variable over-rides:
 - `DEBUG` - Optional. Defaults to 0 (off)
 - `GPG_PASSPHRASE` - Used to sign and verify artifacts during the build
 
+## How to use the plugin
+
+### Building a test catalog for a Java bundle
+
+This goal causes a test catalog to be constructed for all the tests in the child bundles of this maven project.
+
+Goal: `bundletestcat`
+
+Phase: `package`
+
+Input Parameters/Properties:
+- `galasa.skip.bundletestcatalog` required.
+
+Output:
+A test catalog file is generated holding references to all the test classes.
+
+Example:
+```
+<plugin>
+    <groupId>dev.galasa</groupId>
+    <artifactId>galasa-maven-plugin</artifactId>
+    <extensions>true</extensions>
+    <executions>
+        <execution>
+        <id>build-testcatalog</id>
+        <phase>package</phase>
+        <goals>
+            <goal>bundletestcat</goal>
+        </goals>
+        </execution>
+    </executions>
+</plugin>
+```
+
+### Building an OBR resource
+
+Input Parameters/Properties:
+- `galasa.obr.url.type` property = "obrUrlType" optional
+- `includeSelf` optional. Default value is `false`
+
+### Publishing a test catalog to the Galasa ecosystem/server
+
+Goal: `deploytestcat`
+
+Phase: `deploy`
+
+Input Parameters/Properties:
+- `galasa.test.stream` required. A string.
+- `galasa.token` required. An access token for the galasa ecosystem.
+- `galasa.bootstrap` required. A URL to the ecosystem.
+- `galasa.skip.bundletestcatalog` optional. A boolean.
+- `galasa.skip.deploytestcatalog` optional. A boolean.
+
+For example:
+```
+<plugin>
+    <groupId>dev.galasa</groupId>
+    <artifactId>galasa-maven-plugin</artifactId>
+    <extensions>true</extensions>
+    <executions>
+        ...
+        <execution>
+            <id>deploy-testcatalog</id>
+            <phase>deploy</phase>
+            <goals>
+                <goal>deploytestcat</goal>
+            </goals>
+        </execution>
+        ...
+    </executions>
+</plugin>
+```
+
+#### Passing a secret token into a maven plugin. Method 1:
+
+The `galasa.token` maven property is used by this plugin. 
+You can set it using the following in your pom.xml like this:
+
+```
+<properties>
+    ...
+    <galasa.token>${GALASA_TOKEN}</galasa.token>
+    ...
+</properties>
+```
+
+This allows you to call maven and pass the value from the command-line
+```
+mvn clean install deploy "-DGALASA_TOKEN=${GALASA_TOKEN}"
+```
+
+This assumes you have `GALASA_TOKEN` set in your environment.
+
+Note: This method allows the caller of the command-line to pass in 
+whatever value they want, from an environment variable (`GALASA_TOKEN` in this case)
+or from any other value.
+
+This may be useful if you are deploying to multiple Galasa server environments, 
+or switching between tokens used to contact the Galasa Ecosystem.
+
+#### Passing a secret token into a maven plugin. Method 2:
+The `galasa.token` maven property is used by this plugin. 
+You can set it using the following in your pom.xml like this:
+
+```
+<properties>
+    ...
+    <galasa.token>${env.GALASA_TOKEN}</galasa.token>
+    ...
+</properties>
+```
+
+This allows you to set the GALASA_TOKEN as an environment variable, and 
+the maven plugin for Galasa can pick up the value from the environment.
+
+Note: This causes a tighter 'binding' between your environment and the maven 
+build, so all parties using this code need to use the same environment variable
+name.
+
+### Merging two test catalogs
+
+Input Parameters/Properties:
+- `galasa.skip.bundletestcatalog` optional. A boolean.
+- `galasa.build.job` optional. A string.
+
+### Building a gherkin test catalog for Gherkin features
+
+Input Parameters/Properties:
+- `galasa.skip.gherkintestcatalog` required. A boolean.
+
+
+### Building a .zip of gherkin tests
+
+This goal builds a zip file containing all the gherkin feature files.
+
+Goal: `gherkinzip`
+
+Phase: `package`
+
+Input Parameters/Properties:
+- `galasa.skip.gherkinzip` required. A boolean.
+
+
+### Calculating a git commit hash
+
+For example:
+```
+<plugin>
+    <groupId>dev.galasa</groupId>
+    <artifactId>galasa-maven-plugin</artifactId>
+    <extensions>true</extensions>
+    <executions>
+        <execution>
+            <id>process-resources</id>
+            <goals>
+                <goal>gitcommithash</goal>
+            </goals>
+        </execution>
+    </executions>
+</plugin>
+```
+
 ## License
 
 This code is under the [Eclipse Public License 2.0](https://github.com/galasa-dev/maven/blob/main/LICENSE).

--- a/galasa-maven-plugin/pom.xml
+++ b/galasa-maven-plugin/pom.xml
@@ -118,7 +118,6 @@
 			<scope>test</scope>
 			<version>3.3.0</version>
 		</dependency>
-
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
@@ -146,7 +145,7 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.8.5</version>
+			<version>2.10.1</version>
 		</dependency>
 
 		<dependency>
@@ -154,7 +153,27 @@
 			<artifactId>assertj-core</artifactId>
 			<version>3.25.3</version>
 		</dependency>
-	</dependencies>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>2.0.12</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpcore</artifactId>
+			<version>4.4.11</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5.14</version>
+		</dependency>
+
+
+ </dependencies>
 
 	<build>
 		<plugins>

--- a/galasa-maven-plugin/pom.xml
+++ b/galasa-maven-plugin/pom.xml
@@ -126,7 +126,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.9.0</version>
+			<version>2.15.1</version>
 		</dependency>
 
 		<dependency>

--- a/galasa-maven-plugin/pom.xml
+++ b/galasa-maven-plugin/pom.xml
@@ -154,12 +154,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>2.0.12</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpcore</artifactId>
 			<version>4.4.11</version>
@@ -172,7 +166,7 @@
 		</dependency>
 
 
- </dependencies>
+ 	</dependencies>
 
 	<build>
 		<plugins>

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/BuildGherkinZip.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/BuildGherkinZip.java
@@ -17,6 +17,7 @@ import java.util.function.Consumer;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -27,7 +28,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
-import org.apache.maven.shared.utils.io.IOUtil;
 
 @Mojo(name = "gherkinzip", defaultPhase = LifecyclePhase.PACKAGE, threadSafe = true, requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class BuildGherkinZip extends AbstractMojo {
@@ -68,7 +68,7 @@ public class BuildGherkinZip extends AbstractMojo {
                 ZipEntry ze = new ZipEntry(project.getBasedir().toPath().relativize(feature).toString());
                 zos.putNextEntry(ze);
                 FileInputStream fis = new FileInputStream(feature.toString());
-                IOUtil.copy(fis, zos);
+                IOUtils.copy(fis, zos);
                 zos.closeEntry();
                 fis.close();
             }

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/DeployTestCatalog.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/DeployTestCatalog.java
@@ -5,6 +5,7 @@
  */
 package dev.galasa.maven.plugin;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -42,7 +43,7 @@ public class DeployTestCatalog extends AbstractMojo {
     private String       testStream;
 
     // To deploy the test catalog we need to authenticate using this token.
-    @Parameter(defaultValue = "${galasa.token}", readonly = true , required = true)
+    @Parameter(defaultValue = "${galasa.token}", readonly = true , required = false)
     private String       galasaAccessToken;
 
     @Parameter(defaultValue = "${galasa.bootstrap}", readonly = true, required = false)
@@ -105,109 +106,162 @@ public class DeployTestCatalog extends AbstractMojo {
             return;
         }
 
+        Artifact testCatalogArtifact = getTestCatalogArtifact();
+
+        if (testCatalogArtifact == null) {
+            getLog().info("Skipping Bundle Test Catalog deploy, no test catalog artifact present");
+            return;
+        }
+
+        Properties bootstrapProperties = getBootstrapProperties();
+
+        URL testcatalogUrl = calculateTestCatalogUrl(bootstrapProperties);
+
+        checkGalasaAccessTokenIsValid(this.galasaAccessToken); 
+
+        String jwt = getAuthenticatedJwt(this.galasaAccessToken, this.bootstrapUrl) ;
+
+        publishTestCatalogToGalasaServer(testcatalogUrl,jwt, testCatalogArtifact);
+    }
+
+
+    private void checkGalasaAccessTokenIsValid(String galasaAccessToken) throws MojoExecutionException {
+        if (galasaAccessToken==null || galasaAccessToken.isEmpty()) {
+            throw new MojoExecutionException("No Galasa authentication token supplied. Use the galasa-token variable.");
+        }
+    }
+
+    private Artifact getTestCatalogArtifact() {
+        Artifact artifact = null;
+        for (Artifact a : project.getAttachedArtifacts()) {
+            if ("testcatalog".equals(a.getClassifier()) && "json".equals(a.getType())) {
+                artifact = a;
+                break;
+            }
+        }
+        return artifact;
+    }
+
+    private void publishTestCatalogToGalasaServer(URL testCatalogUrl, String jwt, Artifact testCatalogArtifact) throws MojoExecutionException {
+ 
+        HttpURLConnection conn = null ;
         try {
-            Artifact artifact = null;
-            for (Artifact a : project.getAttachedArtifacts()) {
-                if ("testcatalog".equals(a.getClassifier()) && "json".equals(a.getType())) {
-                    artifact = a;
-                    break;
-                }
-            }
-            if (artifact == null) {
-                getLog().info("Skipping Bundle Test Catalog deploy, no test catalog artifact present");
-                return;
-            }
+            conn = (HttpURLConnection) testCatalogUrl.openConnection();
+        } catch (IOException ioEx) {
+            throw new MojoExecutionException("Problem publishing the test catalog. Could not open URL connection to the Galasa server.",ioEx);
+        }
 
-            // *** Get the bootstrap
-            Properties bootstrapProperties = new Properties();
+        if (conn==null) {
+            throw new MojoExecutionException("Deploy to Test Catalog Store failed. Could not open a URL connection to the Galasa server.");
+        } else {
             try {
-                URLConnection connection = bootstrapUrl.openConnection();
-                String msg = MessageFormat.format("execute(): URLConnection: connected to:{0}",connection.getURL().toString());
-                getLog().info(msg);
-                bootstrapProperties.load(connection.getInputStream());
-                getLog().info("execute(): bootstrapProperties loaded: " + bootstrapProperties);
-            } catch (Exception e) {
-                String errMsg = MessageFormat.format("execute() - Unable to load bootstrap properties, Reason: {0}", e);
-                getLog().info(errMsg);
-                throw new MojoExecutionException(errMsg, e);
+                postTestCatalogToGalasaServer(conn, testCatalogUrl, jwt, testCatalogArtifact);
+            } finally {
+                conn.disconnect();
             }
+            getLog().info("Test Catalog successfully deployed to " + testCatalogUrl.toString());
+        }
+    }
 
-            // *** Calculate the testcatalog url
-            String sTestcatalogUrl = bootstrapProperties.getProperty("framework.testcatalog.url");
-            if (sTestcatalogUrl == null || sTestcatalogUrl.trim().isEmpty()) {
-                String sBootstrapUrl = bootstrapUrl.toString();
-                if (!sBootstrapUrl.endsWith("/bootstrap")) {
-                    throw new MojoExecutionException(
-                            "Unable to calculate the test catalog url, the bootstrap url does not end with /bootstrap, need a framework.testcatalog.url property in the bootstrap");
-                }
+    private void postTestCatalogToGalasaServer(HttpURLConnection conn, URL testCatalogUrl, String jwt, Artifact testCatalogArtifact) throws MojoExecutionException {
 
-                sTestcatalogUrl = sBootstrapUrl.substring(0, sBootstrapUrl.length() - 10) + "/testcatalog";
-            }
-
-            if (galasaAccessToken==null || galasaAccessToken.isEmpty()) {
-                throw new MojoExecutionException("No Galasa authentication token supplied. Use the galasa-token variable.");
-            }
-
-            // Get a JWT we can use, based off the galasa-token
-            String jwt = null ;
-            try {
-                String apiServerUrlString = bootstrapUrl.toString().replaceAll("/bootstrap","");
-                HttpClient httpClient = HttpClientBuilder.create().build();
-                URL apiServerUrl = new URL(apiServerUrlString);
-                AuthenticationService authTokenService = new AuthenticationService(apiServerUrl,galasaAccessToken,httpClient);
-                getLog().info("Turning the galasa access token into a jwt");
-                jwt = authTokenService.getJWT();
-                getLog().info("Java Web Token (jwt) obtained from the galasa ecosystem OK.");
-            } catch( Exception ex) {
-                throw new MojoExecutionException(ex.getMessage(),ex);
-            } 
-
-            // *** Get the test catalog url
-            URL testCatalogUrl = new URL(sTestcatalogUrl + "/" + testStream);
-
-            HttpURLConnection conn = (HttpURLConnection) testCatalogUrl.openConnection();
-            
+        int rc = 0 ;
+        String response = "";
+        String message = "";
+        
+        try {
             conn.setDoOutput(true);
             conn.setDoInput(true);
             conn.setRequestMethod("PUT");
             conn.addRequestProperty("Content-Type", "application/json");
             conn.addRequestProperty("Accept", "application/json");
-            conn.addRequestProperty("Authorization", "Bearer "+jwt);
 
-            FileUtils.copyFile(artifact.getFile(), conn.getOutputStream());
-            int rc = conn.getResponseCode();
-            String message = conn.getResponseMessage();
+            conn.addRequestProperty("Authorization", "Bearer "+jwt);
+            conn.addRequestProperty("ClientApiVersion","0.32.0"); // The version of the API we coded this against.
+
+            FileUtils.copyFile(testCatalogArtifact.getFile(), conn.getOutputStream());
+            rc = conn.getResponseCode();
+            message = conn.getResponseMessage();
 
             InputStream is = null;
-            if (rc < HttpURLConnection.HTTP_BAD_REQUEST) {
+            if (rc != HttpURLConnection.HTTP_OK) {
                 is = conn.getInputStream();
             } else {
                 is = conn.getErrorStream();
             }
 
-            String response = "";
             if (is != null) {
                 response = IOUtils.toString(is, "utf-8");
             }
+        } catch(IOException ioEx) {
+            throw new MojoExecutionException("Problem publishing the test catalog. Problem dealing with response from Galasa server.",ioEx);
+        } 
 
-            conn.disconnect();
-
-            if (rc >= HttpURLConnection.HTTP_BAD_REQUEST) {
-                getLog().error("Deploy to Test Catalog Store failed:-");
-                getLog().error(Integer.toString(rc) + " - " + message);
-                if (!response.isEmpty()) {
-                    getLog().error(response);
-                }
-
-                throw new MojoExecutionException("Deploy to Test Catalog Store failed");
+        if (rc != HttpURLConnection.HTTP_OK) {
+            getLog().error("Deploy to Test Catalog Store failed:-");
+            getLog().error(Integer.toString(rc) + " - " + message);
+            if (!response.isEmpty()) {
+                getLog().error(response);
             }
-
-            getLog().info("Test Catalog successfully deployed to " + testCatalogUrl.toString());
-
-        } catch (Throwable t) {
-            throw new MojoExecutionException("Problem publishing the test catalog", t);
         }
-
     }
 
+    private URL calculateTestCatalogUrl(Properties bootstrapProperties) throws MojoExecutionException {
+        String sTestcatalogUrl = bootstrapProperties.getProperty("framework.testcatalog.url");
+        if (sTestcatalogUrl == null || sTestcatalogUrl.trim().isEmpty()) {
+            String sBootstrapUrl = bootstrapUrl.toString();
+            if (!sBootstrapUrl.endsWith("/bootstrap")) {
+                throw new MojoExecutionException(
+                        "Unable to calculate the test catalog url, the bootstrap url does not end with /bootstrap, need a framework.testcatalog.url property in the bootstrap");
+            }
+
+            sTestcatalogUrl = sBootstrapUrl.substring(0, sBootstrapUrl.length() - 10) + "/testcatalog";
+        }
+
+        // convert into a proper URL
+        URL testCatalogUrl ;
+        try {
+            testCatalogUrl = new URL(sTestcatalogUrl + "/" + testStream);
+        } catch(Exception ex) {
+            throw new MojoExecutionException("Problem publishing the test catalog. Badly formed URL to the Galasa server.",ex);
+        }
+        return testCatalogUrl;
+    }
+
+    private Properties getBootstrapProperties() throws MojoExecutionException {
+        Properties bootstrapProperties = new Properties();
+        try {
+            URLConnection connection = bootstrapUrl.openConnection();
+            String msg = MessageFormat.format("execute(): URLConnection: connected to:{0}",connection.getURL().toString());
+            getLog().info(msg);
+            bootstrapProperties.load(connection.getInputStream());
+            getLog().info("execute(): bootstrapProperties loaded: " + bootstrapProperties);
+        } catch (Exception e) {
+            String errMsg = MessageFormat.format("execute() - Unable to load bootstrap properties, Reason: {0}", e);
+            getLog().info(errMsg);
+            throw new MojoExecutionException(errMsg, e);
+        }
+        return bootstrapProperties;
+    }
+
+    /**
+     * Swap the galasa token for a JWT which we can use to talk to the API server on the ecosystem.
+     * @return A JWT string (Java Web Token).
+     * @throws MojoExecutionException
+     */
+    private String getAuthenticatedJwt(String galasaAccessToken, URL bootstrapUrl) throws MojoExecutionException {
+        String jwt;
+        try {
+            String apiServerUrlString = bootstrapUrl.toString().replaceAll("/bootstrap","");
+            HttpClient httpClient = HttpClientBuilder.create().build();
+            URL apiServerUrl = new URL(apiServerUrlString);
+            AuthenticationService authTokenService = new AuthenticationService(apiServerUrl,galasaAccessToken,httpClient);
+            getLog().info("Turning the galasa access token into a jwt");
+            jwt = authTokenService.getJWT();
+            getLog().info("Java Web Token (jwt) obtained from the galasa ecosystem OK.");
+        } catch( Exception ex) {
+            throw new MojoExecutionException(ex.getMessage(),ex);
+        } 
+        return jwt;
+    }
 }

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/StoreGitCommitHash.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/StoreGitCommitHash.java
@@ -7,7 +7,6 @@ package dev.galasa.maven.plugin;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.model.Resource;
@@ -42,9 +41,6 @@ public class StoreGitCommitHash extends AbstractMojo {
                 && !"eclipse-plugin".equals(project.getPackaging())) {
             return;
         }
-
-//        project.addResource(null);
-        List<Resource> resources = project.getResources();
 
         if (hash == null || hash.trim().isEmpty()) {
             hash = "unknown";

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/auth/AuthenticationException.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/auth/AuthenticationException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.maven.plugin.auth;
+
+public class AuthenticationException extends Exception {
+
+    public AuthenticationException(String msg) {
+        super(msg);
+    }
+
+
+    public AuthenticationException(String msg, Throwable cause) {
+        super(msg,cause);
+    }
+    
+}

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/auth/AuthenticationService.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/auth/AuthenticationService.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.maven.plugin.auth;
+
+import java.net.*;
+import java.text.MessageFormat;
+import org.apache.http.client.*;
+import org.apache.http.*;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.util.EntityUtils;
+
+import com.google.gson.*;
+import dev.galasa.maven.plugin.auth.beans.*;
+import dev.galasa.maven.plugin.auth.beans.AuthRequestPayload;
+import dev.galasa.maven.plugin.auth.beans.AuthResponsePayload;
+
+/**
+ * A class which can contact the remote galasa server and get a JWT to use.
+ */
+public class AuthenticationService {
+
+    private static final String GALASA_TOKEN_PART_SEPARATOR = ":";
+
+    private URL apiServerUrl ;
+
+    private String galasaRefreshToken ;
+    private String galasaClientId ;
+
+    private HttpClient httpClient;
+
+    /**
+     * @param apiServerUrl The url of the galasa server
+     * @param galasaAccessToken
+     * @throws AuthenticationException
+     */
+    public AuthenticationService(URL apiServerUrl, String galasaAccessToken, HttpClient httpClient) throws AuthenticationException {
+        validateAndStoreApiServerUrl(apiServerUrl);
+        validateAndStoreGalasaAccessToken(galasaAccessToken);
+        validateAndStoreHttpClient(httpClient);
+    }
+
+    private void validateAndStoreHttpClient(HttpClient httpClient) throws AuthenticationException {
+        if (httpClient == null) {
+            throw new AuthenticationException("Error: Program logic error. No http client supplied to AuthenticationService.");
+        }
+        this.httpClient = httpClient ;
+    }
+
+    private void validateAndStoreApiServerUrl(URL apiServerUrl) throws AuthenticationException {
+        if (apiServerUrl == null) {
+            throw new AuthenticationException("Error: galasa rest api endpoint has not supplied. It is derived from the galasa bootstrap.");
+        }
+        this.apiServerUrl = apiServerUrl ;
+    }
+
+    private void validateAndStoreGalasaAccessToken(String galasaAccessToken) throws AuthenticationException {
+        if (galasaAccessToken == null) {
+            throw new AuthenticationException("Error: galasa-token has not supplied. Get a galasa access token from your Galasa server.");
+        }
+
+        // Split the token into the refresh token and client-id (in that order)
+        String[] parts = galasaAccessToken.split(GALASA_TOKEN_PART_SEPARATOR);
+        if (parts.length!=2) {
+            String msg = "Error: galasa-token value supplied is not a valid galasa authentication token. It should have exactly two parts, separated by a single '"
+                +GALASA_TOKEN_PART_SEPARATOR+"' but it does not.";
+            throw new AuthenticationException(msg);
+        }
+
+        // Remember these pieces so we can use them later.
+        this.galasaRefreshToken = parts[0];
+        this.galasaClientId = parts[1];
+    }
+
+
+    /** 
+     * Exchanges the GALASA_TOKEN for a Java Web Token from the Galasa server, so we can talk to the server
+     * freely after that.
+     */
+    public String getJWT() throws AuthenticationException {
+
+        Gson gson = new GsonFactory().getGson();
+
+        String authEndpointUrl = this.apiServerUrl.toString() + "/auth";
+
+        HttpPost postRequest = createAuthHttpPostRequest(gson, authEndpointUrl);
+
+        HttpResponse response = null;
+        try {
+            response = httpClient.execute(postRequest);
+        } catch (Exception ex) {
+            String msg = MessageFormat.format("Error: Failed to turn the Galasa token into a Java Web Token (JWT) using URL ''{0}''. Cause: {1}",
+                authEndpointUrl,ex.getMessage());
+            throw new AuthenticationException(msg,ex);
+        }
+
+        // Check the auth service returned OK.
+        int statusCode = response.getStatusLine().getStatusCode();
+
+        if (statusCode == HttpStatus.SC_BAD_REQUEST) {
+            AuthError authErrorDetail = null ;
+            try {
+                HttpEntity entity = response.getEntity();
+                String responseBodyString = EntityUtils.toString(entity);
+                authErrorDetail = gson.fromJson(responseBodyString,AuthError.class);
+            } catch(Exception ex) {
+                String msg = MessageFormat.format("Error: Failed to turn the Galasa token into a Java Web Token (JWT) using URL ''{0}''. Response from server (''{1}'') was not OK. Could not parse the returned payload.",
+                    authEndpointUrl, statusCode);
+                throw new AuthenticationException(msg);
+            }
+            // If we got here, we just parsed the error structure coming back from the server...
+            String msg = MessageFormat.format("Error: Failed to turn the Galasa token into a Java Web Token (JWT) using URL ''{0}''. Response from server (''{1}'') was not OK. Error details: code: {2}, message: {3}",
+                authEndpointUrl, statusCode, authErrorDetail.error_code, authErrorDetail.error_message);
+            throw new AuthenticationException(msg);
+
+        }
+
+        if (statusCode != HttpStatus.SC_OK) {
+            String msg = MessageFormat.format("Error: Failed to turn the Galasa token into a Java Web Token (JWT) using URL ''{0}''. Response from server (''{1}'') was not OK.",
+                authEndpointUrl, statusCode);
+            throw new AuthenticationException(msg);
+        }
+
+        String responseBodyString;
+        try {
+            HttpEntity entity = response.getEntity();
+            responseBodyString = EntityUtils.toString(entity);
+        } catch (Exception ex) {
+            String msg = MessageFormat.format("Error: Failed to turn the Galasa token into a Java Web Token (JWT) using URL ''{0}''. Response body parsing issue: Cause: {1}",authEndpointUrl,ex.getMessage());
+            throw new AuthenticationException(msg,ex);
+        }
+
+        AuthResponsePayload responsePayload = gson.fromJson(responseBodyString,AuthResponsePayload.class);
+        String jwt = responsePayload.jwt ;
+
+        return jwt;
+    }
+    
+
+    private HttpPost createAuthHttpPostRequest(Gson gson, String authEndpointUrl) throws AuthenticationException {
+
+        // Create the post request.
+        HttpPost postRequest = new HttpPost(authEndpointUrl);
+        
+        // Set headers..
+        postRequest.setHeader("Content-Type","application/json");
+        postRequest.setHeader("ClientApiVersion","0.32.0");
+
+        // Set the payload..
+        setAuthHttpPostRequestPayload(gson, postRequest, authEndpointUrl);
+
+        return postRequest;
+    }
+
+
+    private void setAuthHttpPostRequestPayload(Gson gson, HttpPost postRequest, String authEndpointUrl) throws AuthenticationException {
+        AuthRequestPayload authRequestPayload = new AuthRequestPayload();
+        authRequestPayload.client_id = this.galasaClientId;
+        authRequestPayload.refresh_token = this.galasaRefreshToken;
+
+        String payloadString = gson.toJson(authRequestPayload);
+
+        try {
+            StringEntity payload = new StringEntity(payloadString);
+            postRequest.setEntity(payload);
+        } catch (Exception ex ) {
+            String msg = MessageFormat.format("Error: Failed to turn the Galasa token into a Java Web Token (JWT) using URL ''{0}''. Cause: ",authEndpointUrl,ex.getMessage());
+            throw new AuthenticationException(msg,ex);
+        }
+    }
+}

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/auth/GsonFactory.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/auth/GsonFactory.java
@@ -1,0 +1,11 @@
+package dev.galasa.maven.plugin.auth;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+public class GsonFactory {
+    public Gson getGson() {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        return gson ;
+    }
+}

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/auth/beans/AuthError.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/auth/beans/AuthError.java
@@ -1,0 +1,6 @@
+package dev.galasa.maven.plugin.auth.beans;
+
+public class AuthError {
+    public String error_message;
+    public int error_code;
+}

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/auth/beans/AuthRequestPayload.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/auth/beans/AuthRequestPayload.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.maven.plugin.auth.beans;
+
+public class AuthRequestPayload {
+    public String client_id ;
+    public String secret ;
+    public String refresh_token ;
+    public String code ; 
+}

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/auth/beans/AuthResponsePayload.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/auth/beans/AuthResponsePayload.java
@@ -1,0 +1,6 @@
+package dev.galasa.maven.plugin.auth.beans;
+
+public class AuthResponsePayload {
+    public String jwt	;
+    public String refresh_token ;
+}

--- a/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/MockHttpClient.java
+++ b/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/MockHttpClient.java
@@ -1,0 +1,85 @@
+package dev.galasa.maven.plugin;
+
+import java.io.IOException;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.conn.ClientConnectionManager;
+import org.apache.http.params.HttpParams;
+import org.apache.http.protocol.HttpContext;
+
+@SuppressWarnings("deprecation")
+public class MockHttpClient implements HttpClient {
+
+    private int requestsProcessedCount = 0 ;
+
+    public void incrementRequestsProcessedCount() {
+        requestsProcessedCount+=1;
+    }
+
+    public int getRequestsProcessed() {
+        return this.requestsProcessedCount;
+    }
+
+    @Override
+    public HttpParams getParams() {
+        throw new UnsupportedOperationException("Unimplemented method 'getParams'");
+    }
+
+    @Override
+    public ClientConnectionManager getConnectionManager() {
+        throw new UnsupportedOperationException("Unimplemented method 'getConnectionManager'");
+    }
+
+    @Override
+    public HttpResponse execute(HttpUriRequest request) throws IOException, ClientProtocolException {
+        throw new UnsupportedOperationException("Unimplemented method 'execute'");
+    }
+
+    @Override
+    public HttpResponse execute(HttpUriRequest request, HttpContext context)
+            throws IOException, ClientProtocolException {
+        throw new UnsupportedOperationException("Unimplemented method 'execute'");
+    }
+
+    @Override
+    public HttpResponse execute(HttpHost target, HttpRequest request) throws IOException, ClientProtocolException {
+        throw new UnsupportedOperationException("Unimplemented method 'execute'");
+    }
+
+    @Override
+    public HttpResponse execute(HttpHost target, HttpRequest request, HttpContext context)
+            throws IOException, ClientProtocolException {
+        throw new UnsupportedOperationException("Unimplemented method 'execute'");
+    }
+
+    @Override
+    public <T> T execute(HttpUriRequest request, ResponseHandler<? extends T> responseHandler)
+            throws IOException, ClientProtocolException {
+        throw new UnsupportedOperationException("Unimplemented method 'execute'");
+    }
+
+    @Override
+    public <T> T execute(HttpUriRequest request, ResponseHandler<? extends T> responseHandler, HttpContext context)
+            throws IOException, ClientProtocolException {
+        throw new UnsupportedOperationException("Unimplemented method 'execute'");
+    }
+
+    @Override
+    public <T> T execute(HttpHost target, HttpRequest request, ResponseHandler<? extends T> responseHandler)
+            throws IOException, ClientProtocolException {
+        throw new UnsupportedOperationException("Unimplemented method 'execute'");
+    }
+
+    @Override
+    public <T> T execute(HttpHost target, HttpRequest request, ResponseHandler<? extends T> responseHandler,
+            HttpContext context) throws IOException, ClientProtocolException {
+        throw new UnsupportedOperationException("Unimplemented method 'execute'");
+    }
+    
+}

--- a/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/auth/AuthenticationServiceTest.java
+++ b/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/auth/AuthenticationServiceTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.maven.plugin.auth;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.IOException;
+import java.net.URL;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
+import org.junit.Test;
+import com.google.gson.Gson;
+import org.apache.http.*;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import dev.galasa.maven.plugin.MockHttpClient;
+import dev.galasa.maven.plugin.auth.beans.*;
+
+
+public class AuthenticationServiceTest { 
+
+    @Test
+    public void testAuthServiceComplainsIfNullGalasaAuthTokenSupplied() throws Exception {
+        Exception ex = catchException( ()-> new AuthenticationService(new URL("http://not-null.com"), null, new MockHttpClient() ));
+        assertThat(ex).isInstanceOf(AuthenticationException.class);
+    }
+
+    @Test
+    public void testAuthServiceComplainsIfNullApiServerUrlSupplied() throws Exception {
+        Exception ex = catchException( ()-> new AuthenticationService(null, "could-be-a:valid-token", new MockHttpClient()));
+        assertThat(ex).isInstanceOf(AuthenticationException.class);
+    }
+
+    @Test
+    public void testAuthServiceGivenTokenWithNoSeparatorFails() throws Exception {
+        Exception ex = catchException( ()-> new AuthenticationService(new URL("http://not-null.com"), "no-separator-in-this-token", new MockHttpClient()));
+        assertThat(ex).isInstanceOf(AuthenticationException.class);
+    }
+
+    @Test
+    public void testAuthServiceGivenTokenWithTwoSeparatorsFails() throws Exception {
+        Exception ex = catchException( ()-> new AuthenticationService(new URL("http://not-null.com"), "too-many:separators:here", new MockHttpClient()));
+        assertThat(ex).isInstanceOf(AuthenticationException.class);
+    }
+
+    @Test
+    public void testAuthServiceGivenNullHttpClientFails() throws Exception {
+        Exception ex = catchException( ()-> new AuthenticationService(new URL("http://not-null.com"), "could-be-a:valid-token", null));
+        assertThat(ex).isInstanceOf(AuthenticationException.class);
+    }
+
+
+
+    @Test
+    public void testAuthServiceGetsHttpNotFoundResponseThrowsDecentError() throws Exception {
+
+        MockHttpClient mockHttpClient = new MockHttpClient() {
+            @Override
+            public HttpResponse execute(HttpUriRequest request) throws IOException, ClientProtocolException {
+                // Note that the code under test has asked for execution of an Http request...
+                super.incrementRequestsProcessedCount();
+
+                assertThat(request.getURI().toString()).isEqualTo("https://mock-service.com/auth");
+
+                StatusLine statusLine = new BasicStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_NOT_FOUND, "");
+                BasicHttpResponse response = new BasicHttpResponse(statusLine);
+                return response;
+            }
+        };
+
+        AuthenticationService service = new AuthenticationService(new URL("https://mock-service.com"), "could-be-a:valid-token", mockHttpClient);
+
+
+        Exception gotBackException = catchException(()->service.getJWT());
+        
+        assertThat(mockHttpClient.getRequestsProcessed()).as("code under tests never requested a JWT from the server.").isEqualTo(1);
+        assertThat(gotBackException).isInstanceOf(AuthenticationException.class);
+        AuthenticationException gotBackAuthEx = (AuthenticationException)gotBackException;
+        assertThat(gotBackAuthEx.getMessage()).contains("Response from server");
+
+    }
+
+    @Test
+    public void testAuthServiceGetsExceptionFromHttpClientThrowsDecentError() throws Exception {
+
+        MockHttpClient mockHttpClient = new MockHttpClient() {
+            @Override
+            public HttpResponse execute(HttpUriRequest request) throws IOException, ClientProtocolException {
+                // Note that the code under test has asked for execution of an Http request...
+                super.incrementRequestsProcessedCount();
+
+                throw new IOException("Simulated failure from a unit test");
+            }
+        };
+
+        AuthenticationService service = new AuthenticationService(new URL("https://mock-service.com"), "could-be-a:valid-token", mockHttpClient);
+
+
+        Exception gotBackException = catchException(()->service.getJWT());
+        
+        assertThat(mockHttpClient.getRequestsProcessed()).as("code under tests never requested a JWT from the server.").isEqualTo(1);
+        assertThat(gotBackException).isInstanceOf(AuthenticationException.class);
+        AuthenticationException gotBackAuthEx = (AuthenticationException)gotBackException;
+        assertThat(gotBackAuthEx.getMessage()).contains("Simulated failure from a unit test");
+
+    }
+
+    @Test
+    public void testAuthServiceCanGetAJWT() throws Exception {
+
+        String expectedClientId = "asdasdasads";
+        String expectedRefreshToken = "valid-token";
+        String expectedJwt = "my-jwt";
+
+        MockHttpClient mockHttpClient = new MockHttpClient() {
+            @Override
+            public HttpResponse execute(HttpUriRequest request) throws IOException, ClientProtocolException {
+                // Note that the code under test has asked for execution of an Http request...
+                super.incrementRequestsProcessedCount();
+
+                assertThat(request.getURI().toString()).isEqualTo("https://mock-service.com/auth");
+
+                HttpEntity entity = ((HttpEntityEnclosingRequest) request).getEntity();
+                String requestBodyString = EntityUtils.toString(entity);
+
+                Gson gson = new GsonFactory().getGson();
+                AuthRequestPayload payload = gson.fromJson(requestBodyString, AuthRequestPayload.class);
+
+                assertThat(payload.client_id).as("Client id field in request to auth endpoint is bad.").isEqualTo(expectedClientId);
+                assertThat(payload.code).isNull();
+                assertThat(payload.refresh_token).as("refresh token field in request to auth endpoint is bad.").isEqualTo(expectedRefreshToken);
+                assertThat(payload.secret).isNull();
+
+                // The request looks OK.
+
+                // Formulate a mock response...
+                StatusLine statusLine = new BasicStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "");
+                BasicHttpResponse response = new BasicHttpResponse(statusLine);
+
+                AuthResponsePayload responsePayload = new AuthResponsePayload();
+                responsePayload.jwt = expectedJwt;
+                responsePayload.refresh_token = null;
+
+                String responseBodyString = gson.toJson(responsePayload);
+                StringEntity responsePayloadEntity = new StringEntity(responseBodyString, ContentType.APPLICATION_JSON);
+                response.setEntity(responsePayloadEntity);
+
+                return response;
+            }
+        };
+
+        AuthenticationService service = new AuthenticationService(new URL("https://mock-service.com"), expectedRefreshToken+":"+expectedClientId, mockHttpClient);
+
+        String jwt = service.getJWT();
+
+        assertThat(mockHttpClient.getRequestsProcessed()).as("code under tests never requested a JWT from the server.").isEqualTo(1);
+        assertThat(jwt).isNotNull().isNotBlank().isEqualTo(expectedJwt);
+    }
+
+
+
+    @Test
+    public void testRejectedTokenCausesErrorToBeReported() throws Exception {
+
+        String expectedClientId = "asdasdasads";
+        String expectedRefreshToken = "valid-token";
+        String expectedJwt = "my-jwt";
+
+        MockHttpClient mockHttpClient = new MockHttpClient() {
+            @Override
+            public HttpResponse execute(HttpUriRequest request) throws IOException, ClientProtocolException {
+                // Note that the code under test has asked for execution of an Http request...
+                super.incrementRequestsProcessedCount();
+
+                assertThat(request.getURI().toString()).isEqualTo("https://mock-service.com/auth");
+
+                HttpEntity entity = ((HttpEntityEnclosingRequest) request).getEntity();
+                String requestBodyString = EntityUtils.toString(entity);
+
+                Gson gson = new GsonFactory().getGson();
+                AuthRequestPayload payload = gson.fromJson(requestBodyString, AuthRequestPayload.class);
+
+                assertThat(payload.client_id).as("Client id field in request to auth endpoint is bad.").isEqualTo(expectedClientId);
+                assertThat(payload.code).isNull();
+                assertThat(payload.refresh_token).as("refresh token field in request to auth endpoint is bad.").isEqualTo(expectedRefreshToken);
+                assertThat(payload.secret).isNull();
+
+                // The request looks OK.
+
+                // Formulate a mock response...
+                StatusLine statusLine = new BasicStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_BAD_REQUEST, "");
+                BasicHttpResponse response = new BasicHttpResponse(statusLine);
+
+                AuthError authError = new AuthError();
+                authError.error_code = 99;
+                authError.error_message = "The galasa token was bad";
+
+                String responseBodyString = gson.toJson(authError);
+                StringEntity responsePayloadEntity = new StringEntity(responseBodyString, ContentType.APPLICATION_JSON);
+                response.setEntity(responsePayloadEntity);
+
+                return response;
+            }
+        };
+
+        AuthenticationService service = new AuthenticationService(new URL("https://mock-service.com"), expectedRefreshToken+":"+expectedClientId, mockHttpClient);
+
+        Throwable t = catchThrowable( ()-> { service.getJWT(); });
+
+        assertThat(t).isNotNull().isInstanceOf(AuthenticationException.class);
+        AuthenticationException ex = (AuthenticationException)t;
+        assertThat(ex).hasMessageContaining("The galasa token was bad");
+
+    }
+
+
+    // This test was helpful to show that the AuthenticationService code should work against a real server.
+    // To use it, you need to plug-in your own token.
+    // @Test
+    // public void testCanTargetARealEcosystem() throws Exception {
+    //     String refreshToken = "xxx";
+    //     String clientId = "xxx";
+    //     String apiServerUrlString = "https://galasa-ecosystem1.galasa.dev/api";
+    //     HttpClient httpClient = HttpClientBuilder.create().build();
+    //     URL apiServerUrl = new URL(apiServerUrlString);
+    //     AuthenticationService service = new AuthenticationService(apiServerUrl, refreshToken+":"+clientId, httpClient);
+    //     String jwt = service.getJWT();
+    //     assertThat(jwt).isNotBlank().contains("zzzzz");
+    // }
+}

--- a/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/auth/AuthenticationServiceTest.java
+++ b/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/auth/AuthenticationServiceTest.java
@@ -10,7 +10,6 @@ import static org.assertj.core.api.Assertions.*;
 import java.io.IOException;
 import java.net.URL;
 import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
@@ -19,7 +18,6 @@ import com.google.gson.Gson;
 import org.apache.http.*;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import dev.galasa.maven.plugin.MockHttpClient;
 import dev.galasa.maven.plugin.auth.beans.*;
@@ -172,7 +170,6 @@ public class AuthenticationServiceTest {
 
         String expectedClientId = "asdasdasads";
         String expectedRefreshToken = "valid-token";
-        String expectedJwt = "my-jwt";
 
         MockHttpClient mockHttpClient = new MockHttpClient() {
             @Override

--- a/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/auth/AuthenticationServiceTest.java
+++ b/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/auth/AuthenticationServiceTest.java
@@ -228,7 +228,7 @@ public class AuthenticationServiceTest {
     // public void testCanTargetARealEcosystem() throws Exception {
     //     String refreshToken = "xxx";
     //     String clientId = "xxx";
-    //     String apiServerUrlString = "https://galasa-ecosystem1.galasa.dev/api";
+    //     String apiServerUrlString = "https:/my.server/api";
     //     HttpClient httpClient = HttpClientBuilder.create().build();
     //     URL apiServerUrl = new URL(apiServerUrlString);
     //     AuthenticationService service = new AuthenticationService(apiServerUrl, refreshToken+":"+clientId, httpClient);


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

- Insist on the galasa.token information to push a test catalog to the galasa ecosystem
- Improve logging and errors in general
- Turn the galasa.token value into a JWT using the auth server
- Pass the JWT token on the request to update the test catalog
- Documentation for the maven plugin

This PR is in response to this issue: https://github.com/galasa-dev/projectmanagement/issues/1748