### PR TITLE
maven plugin deploys test catalog with or without a galasa.token

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ Phase: `deploy`
 
 Input Parameters/Properties:
 - `galasa.test.stream` required. A string.
-- `galasa.token` required. An access token for the galasa ecosystem.
+- `galasa.token` optional. An access token for the galasa ecosystem, if that ecosytem is using authentication.
 - `galasa.bootstrap` required. A URL to the ecosystem.
-- `galasa.skip.bundletestcatalog` optional. A boolean.
-- `galasa.skip.deploytestcatalog` optional. A boolean.
+- `galasa.skip.bundletestcatalog` optional. A boolean. If set to true, the test catalog is not deployed to the Galasa server.
+- `galasa.skip.deploytestcatalog` optional. A boolean. If set to true, the test catalog is not deployed to the Galasa server.
 
 For example:
 ```

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/DeployTestCatalog.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/DeployTestCatalog.java
@@ -63,8 +63,6 @@ public class DeployTestCatalog extends AbstractMojo {
 
     protected BootstrapLoader bootstrapLoader = new BootstrapLoaderImpl();
 
-    public static final boolean DEFAULT_ASSUMPTION_AUTHENTICATION_ENABLED = false ;
-
     public void execute() throws MojoExecutionException, MojoFailureException {
 
         boolean skip = (skipBundleTestCatalog || skipBundleTestCatalogOldSpelling);

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/DeployTestCatalog.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/DeployTestCatalog.java
@@ -48,20 +48,25 @@ public class DeployTestCatalog extends AbstractMojo {
     @Parameter(defaultValue = "${galasa.skip.bundletestcatatlog}", readonly = true, required = false)
     public boolean      skipBundleTestCatalogOldSpelling;
     
-    @Parameter(defaultValue = "${galasa.skip.bundletestcatalog}", name="skip" , readonly = true, required = false)
+    @Parameter(defaultValue = "${galasa.skip.bundletestcatalog}", readonly = true, required = false)
     public boolean      skipBundleTestCatalog;
     
     // This spelling of the property is old/wrong/deprecated.
     @Parameter(defaultValue = "${galasa.skip.deploytestcatatlog}" , readonly = true, required = false)
     public boolean      skipDeployTestCatalogOldSpelling;
     
-    @Parameter(defaultValue = "${galasa.skip.deploytestcatalog}", name="skipDeploy" , readonly = true, required = false)
+    @Parameter(defaultValue = "${galasa.skip.deploytestcatalog}", readonly = true, required = false)
     public boolean      skipDeployTestCatalog;
 
     // A protected variable so we can inject a mock factory if needed during unit testing.
     protected AuthenticationServiceFactory authFactory = new AuthenticationServiceFactoryImpl();
 
     protected BootstrapLoader bootstrapLoader = new BootstrapLoaderImpl();
+
+    public static final boolean DEFAULT_ASSUMPTION_AUTHENTICATION_ENABLED = false ;
+
+    public static final String BOOTSTRAP_PROPERTY_NAME_IS_AUTH_ENABLED = "framework.auth.isEnabled";
+
 
     public void execute() throws MojoExecutionException, MojoFailureException {
 
@@ -100,21 +105,36 @@ public class DeployTestCatalog extends AbstractMojo {
 
         URL testcatalogUrl = calculateTestCatalogUrl(bootstrapProperties, this.testStream, this.bootstrapUrl);
 
-        checkGalasaAccessTokenIsValid(this.galasaAccessToken); 
-
-        String jwt = getAuthenticatedJwt(this.authFactory, this.galasaAccessToken, this.bootstrapUrl) ;
+        String jwt = null ;
+        // For now, if no galasa token is supplied, that's ok. It's optional.   
+        if (this.galasaAccessToken==null || this.galasaAccessToken.isEmpty()) {
+            // No galasa access token supplied by the user. So not going to pass a JWT.
+        } else {
+            jwt = getAuthenticatedJwt(this.authFactory, this.galasaAccessToken, this.bootstrapUrl) ;
+        }
 
         publishTestCatalogToGalasaServer(testcatalogUrl,jwt, testCatalogArtifact);
     }
 
-    private void checkGalasaAccessTokenIsValid(String galasaAccessToken) throws MojoExecutionException {
-        if (galasaAccessToken==null || galasaAccessToken.isEmpty()) {
-            String msg = "No Galasa authentication token supplied. Set the galasa.token property."+
-            " The token is required to communicate with the Galasa server."+
-            " Obtain a personal access token using the Galasa web user interface for the ecosystem you are trying to publish the test catalog to.";
-            getLog().error(msg);
-            throw new MojoExecutionException(msg);
+    // Protected so that we can easily unit test this method.
+    protected boolean calculateWhetherAuthenticationIsEnabledOnServer(Properties bootstrapProperties) {
+        boolean isAuthEnabled = DEFAULT_ASSUMPTION_AUTHENTICATION_ENABLED;
+
+        String isEnabledPropStr = bootstrapProperties.getProperty(BOOTSTRAP_PROPERTY_NAME_IS_AUTH_ENABLED);
+        if (isEnabledPropStr==null) {
+            if (DEFAULT_ASSUMPTION_AUTHENTICATION_ENABLED) {
+                getLog().info("Bootstrap properties from server do not include "+BOOTSTRAP_PROPERTY_NAME_IS_AUTH_ENABLED+" so we assume server is insisting on authentication.");
+            } else {
+                getLog().info("Bootstrap properties from server do not include "+BOOTSTRAP_PROPERTY_NAME_IS_AUTH_ENABLED+" so we assume server is not insisting on authentication.");
+            }
+        } else {
+            if (isEnabledPropStr.equalsIgnoreCase("true") ) {
+                getLog().info("Bootstrap properties from server include the property "+BOOTSTRAP_PROPERTY_NAME_IS_AUTH_ENABLED+" so we know the server requires authentication.");
+                isAuthEnabled = true;
+            }
         }
+
+        return isAuthEnabled;
     }
 
     private Artifact getTestCatalogArtifact() {
@@ -164,7 +184,13 @@ public class DeployTestCatalog extends AbstractMojo {
             conn.addRequestProperty("Content-Type", "application/json");
             conn.addRequestProperty("Accept", "application/json");
 
-            conn.addRequestProperty("Authorization", "Bearer "+jwt);
+            // Only add the jwt header if we have a jwt value.
+            if (jwt == null) {
+                getLog().info("Not sending a JWT bearer token to the server, as the galasa.token was not supplied.");
+            } else {
+                conn.addRequestProperty("Authorization", "Bearer "+jwt);
+            }
+
             conn.addRequestProperty("ClientApiVersion","0.32.0"); // The version of the API we coded this against.
 
             FileUtils.copyFile(testCatalogArtifact.getFile(), conn.getOutputStream());

--- a/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/DeployTestCatalog.java
+++ b/galasa-maven-plugin/src/main/java/dev/galasa/maven/plugin/DeployTestCatalog.java
@@ -65,9 +65,6 @@ public class DeployTestCatalog extends AbstractMojo {
 
     public static final boolean DEFAULT_ASSUMPTION_AUTHENTICATION_ENABLED = false ;
 
-    public static final String BOOTSTRAP_PROPERTY_NAME_IS_AUTH_ENABLED = "framework.auth.isEnabled";
-
-
     public void execute() throws MojoExecutionException, MojoFailureException {
 
         boolean skip = (skipBundleTestCatalog || skipBundleTestCatalogOldSpelling);
@@ -107,34 +104,12 @@ public class DeployTestCatalog extends AbstractMojo {
 
         String jwt = null ;
         // For now, if no galasa token is supplied, that's ok. It's optional.   
-        if (this.galasaAccessToken==null || this.galasaAccessToken.isEmpty()) {
-            // No galasa access token supplied by the user. So not going to pass a JWT.
-        } else {
+        // If no galasa access token supplied by the user, the jwt will stay as null.
+        if ( (this.galasaAccessToken!=null) && (!this.galasaAccessToken.isEmpty()) ) {
             jwt = getAuthenticatedJwt(this.authFactory, this.galasaAccessToken, this.bootstrapUrl) ;
         }
 
         publishTestCatalogToGalasaServer(testcatalogUrl,jwt, testCatalogArtifact);
-    }
-
-    // Protected so that we can easily unit test this method.
-    protected boolean calculateWhetherAuthenticationIsEnabledOnServer(Properties bootstrapProperties) {
-        boolean isAuthEnabled = DEFAULT_ASSUMPTION_AUTHENTICATION_ENABLED;
-
-        String isEnabledPropStr = bootstrapProperties.getProperty(BOOTSTRAP_PROPERTY_NAME_IS_AUTH_ENABLED);
-        if (isEnabledPropStr==null) {
-            if (DEFAULT_ASSUMPTION_AUTHENTICATION_ENABLED) {
-                getLog().info("Bootstrap properties from server do not include "+BOOTSTRAP_PROPERTY_NAME_IS_AUTH_ENABLED+" so we assume server is insisting on authentication.");
-            } else {
-                getLog().info("Bootstrap properties from server do not include "+BOOTSTRAP_PROPERTY_NAME_IS_AUTH_ENABLED+" so we assume server is not insisting on authentication.");
-            }
-        } else {
-            if (isEnabledPropStr.equalsIgnoreCase("true") ) {
-                getLog().info("Bootstrap properties from server include the property "+BOOTSTRAP_PROPERTY_NAME_IS_AUTH_ENABLED+" so we know the server requires authentication.");
-                isAuthEnabled = true;
-            }
-        }
-
-        return isAuthEnabled;
     }
 
     private Artifact getTestCatalogArtifact() {
@@ -186,7 +161,7 @@ public class DeployTestCatalog extends AbstractMojo {
 
             // Only add the jwt header if we have a jwt value.
             if (jwt == null) {
-                getLog().info("Not sending a JWT bearer token to the server, as the galasa.token was not supplied.");
+                getLog().info("Not sending a JWT bearer token to the server, as the galasa.token property was not supplied.");
             } else {
                 conn.addRequestProperty("Authorization", "Bearer "+jwt);
             }

--- a/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/DeployTestCatalogTest.java
+++ b/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/DeployTestCatalogTest.java
@@ -254,51 +254,7 @@ public class DeployTestCatalogTest {
         assertThat(ex).hasMessageContaining("Unable to calculate the test catalog url, the bootstrap url does not end with /bootstrap, need a framework.testcatalog.url property in the bootstrap");
     }
 
-    @Test
-    public void testCalcServerUsesAuthenticationWhenPropMissingShouldBeFalse() {
-        DeployTestCatalog command = new DeployTestCatalog();
-        Properties props = new Properties();
-        boolean isAuthEnabled = command.calculateWhetherAuthenticationIsEnabledOnServer(props);
-        assertThat(isAuthEnabled).isFalse();
-    }
-
-    @Test
-    public void testCalcServerUsesAuthenticationWhenPropFalseShouldBeFalse() {
-        DeployTestCatalog command = new DeployTestCatalog();
-        Properties props = new Properties();
-        props.setProperty(DeployTestCatalog.BOOTSTRAP_PROPERTY_NAME_IS_AUTH_ENABLED,"false");
-        boolean isAuthEnabled = command.calculateWhetherAuthenticationIsEnabledOnServer(props);
-        assertThat(isAuthEnabled).isFalse();
-    }
-
-    @Test
-    public void testCalcServerUsesAuthenticationWhenPropTRUEShouldBeTrue() {
-        DeployTestCatalog command = new DeployTestCatalog();
-        Properties props = new Properties();
-        props.setProperty(DeployTestCatalog.BOOTSTRAP_PROPERTY_NAME_IS_AUTH_ENABLED,"TRUE");
-        boolean isAuthEnabled = command.calculateWhetherAuthenticationIsEnabledOnServer(props);
-        assertThat(isAuthEnabled).isTrue();
-    }
-
-    @Test
-    public void testCalcServerUsesAuthenticationWhenPropTrueShouldBeTrue() {
-        DeployTestCatalog command = new DeployTestCatalog();
-        Properties props = new Properties();
-        props.setProperty(DeployTestCatalog.BOOTSTRAP_PROPERTY_NAME_IS_AUTH_ENABLED,"True");
-        boolean isAuthEnabled = command.calculateWhetherAuthenticationIsEnabledOnServer(props);
-        assertThat(isAuthEnabled).isTrue();
-    }
-
-    @Test
-    public void testCalcServerUsesAuthenticationWhenProptrueShouldBeTrue() {
-        DeployTestCatalog command = new DeployTestCatalog();
-        Properties props = new Properties();
-        props.setProperty(DeployTestCatalog.BOOTSTRAP_PROPERTY_NAME_IS_AUTH_ENABLED,"true");
-        boolean isAuthEnabled = command.calculateWhetherAuthenticationIsEnabledOnServer(props);
-        assertThat(isAuthEnabled).isTrue();
-    }
-
-
+ 
     // This is my exploration unit test.
     //
     // The unit tests are not yet complete, as they don't test the last piece where the test catalog file is

--- a/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/DeployTestCatalogTest.java
+++ b/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/DeployTestCatalogTest.java
@@ -254,38 +254,50 @@ public class DeployTestCatalogTest {
         assertThat(ex).hasMessageContaining("Unable to calculate the test catalog url, the bootstrap url does not end with /bootstrap, need a framework.testcatalog.url property in the bootstrap");
     }
 
-    @SuppressWarnings("deprecation")
     @Test
-    public void TestFailsIfNoGalasaAccessToken() throws Exception {
+    public void testCalcServerUsesAuthenticationWhenPropMissingShouldBeFalse() {
         DeployTestCatalog command = new DeployTestCatalog();
-        MockLog mockLog = new MockLog();
-        command.setLog(mockLog);
-
-        command.testStream = "myTestStream";
-        command.bootstrapUrl = new URL("http://myBootstrapUrl/bootstrap");
-
-        MavenProject project = new MavenProject();
-        project.setPackaging("galasa-obr");
-        command.project = project;
-
-        MockArtifact testCatalogArtifact = new MockArtifact();
-        project.addAttachedArtifact(testCatalogArtifact);
-        testCatalogArtifact.type = "json";
-        testCatalogArtifact.classifier = "testcatalog";
-        
-        // Set a mock boostrap loader...
-        command.bootstrapLoader = new BootstrapLoader() {
-            @Override
-            public Properties getBootstrapProperties(URL bootstrapUrl, Log log) throws MojoExecutionException {
-                return new Properties();
-            }
-        };
-
-        Exception ex = catchException( ()-> command.execute() );
-        assertThat(ex).isInstanceOf(MojoExecutionException.class);
-        assertThat(ex).hasMessageContaining("No Galasa authentication token supplied. Set the galasa.token property. The token is required to communicate with the Galasa server");
-
+        Properties props = new Properties();
+        boolean isAuthEnabled = command.calculateWhetherAuthenticationIsEnabledOnServer(props);
+        assertThat(isAuthEnabled).isFalse();
     }
+
+    @Test
+    public void testCalcServerUsesAuthenticationWhenPropFalseShouldBeFalse() {
+        DeployTestCatalog command = new DeployTestCatalog();
+        Properties props = new Properties();
+        props.setProperty(DeployTestCatalog.BOOTSTRAP_PROPERTY_NAME_IS_AUTH_ENABLED,"false");
+        boolean isAuthEnabled = command.calculateWhetherAuthenticationIsEnabledOnServer(props);
+        assertThat(isAuthEnabled).isFalse();
+    }
+
+    @Test
+    public void testCalcServerUsesAuthenticationWhenPropTRUEShouldBeTrue() {
+        DeployTestCatalog command = new DeployTestCatalog();
+        Properties props = new Properties();
+        props.setProperty(DeployTestCatalog.BOOTSTRAP_PROPERTY_NAME_IS_AUTH_ENABLED,"TRUE");
+        boolean isAuthEnabled = command.calculateWhetherAuthenticationIsEnabledOnServer(props);
+        assertThat(isAuthEnabled).isTrue();
+    }
+
+    @Test
+    public void testCalcServerUsesAuthenticationWhenPropTrueShouldBeTrue() {
+        DeployTestCatalog command = new DeployTestCatalog();
+        Properties props = new Properties();
+        props.setProperty(DeployTestCatalog.BOOTSTRAP_PROPERTY_NAME_IS_AUTH_ENABLED,"True");
+        boolean isAuthEnabled = command.calculateWhetherAuthenticationIsEnabledOnServer(props);
+        assertThat(isAuthEnabled).isTrue();
+    }
+
+    @Test
+    public void testCalcServerUsesAuthenticationWhenProptrueShouldBeTrue() {
+        DeployTestCatalog command = new DeployTestCatalog();
+        Properties props = new Properties();
+        props.setProperty(DeployTestCatalog.BOOTSTRAP_PROPERTY_NAME_IS_AUTH_ENABLED,"true");
+        boolean isAuthEnabled = command.calculateWhetherAuthenticationIsEnabledOnServer(props);
+        assertThat(isAuthEnabled).isTrue();
+    }
+
 
     // This is my exploration unit test.
     //

--- a/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/DeployTestCatalogTest.java
+++ b/galasa-maven-plugin/src/test/java/dev/galasa/maven/plugin/DeployTestCatalogTest.java
@@ -10,7 +10,6 @@ import java.util.Properties;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.Test;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 
 public class DeployTestCatalogTest { 


### PR DESCRIPTION
- empty to force a build to run
- galasa-token is optional. It gets used if it is supplied
