### PR TITLE
added project name to pom file

### DIFF
--- a/galasa-maven-plugin/pom.xml
+++ b/galasa-maven-plugin/pom.xml
@@ -9,7 +9,7 @@
 	<packaging>maven-plugin</packaging>
 	<version>0.33.0</version>
 
-	
+	<name>Galasa Maven Plugin</name>
 	<description>Maven plugin for build Galasa artifacts such as the OBR, Test Catalog</description>
 	<url>https://galasa.dev</url>
 


### PR DESCRIPTION
## Why?
This change is to correct the issue with the pom validation failing during the release due to the missing project name.
![image](https://github.com/galasa-dev/maven/assets/115538070/95c3b6c7-47c8-4df8-897a-140dfd43b9c3)
