### PR TITLE
Use new gradle image in GHCR now its available

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -102,8 +102,8 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           build-args: |
-            dockerRepository=harbor.galasa.dev
-            tag=main
+            dockerRepository=ghcr.io
+            tag=${{ env.BRANCH }}
 
       # Recycle the development Maven registry app in ArgoCD
       # Authenticate using a token passed in as an environment variable

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -84,5 +84,5 @@ jobs:
             load: true
             tags: maven:test
             build-args: |
-              dockerRepository=harbor.galasa.dev
+              dockerRepository=ghcr.io
               tag=main

--- a/dockerfiles/dockerfile
+++ b/dockerfiles/dockerfile
@@ -1,6 +1,6 @@
 ARG dockerRepository
 ARG tag
-FROM ${dockerRepository}/galasadev/galasa-gradle:${tag}
+FROM ${dockerRepository}/galasa-dev/gradle-maven-artefacts:${tag}
 
 COPY repo/ /usr/local/apache2/htdocs/
 COPY maven.githash /usr/local/apache2/htdocs/maven.githash


### PR DESCRIPTION
Updating the Dockerfile FROM and the required build arguments to use the new image containing gradle's maven artefacts in GHCR now its available.