### PR TITLE
Add trigger for framework with GH CLI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,7 @@
 name: Main build
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 
@@ -112,4 +113,22 @@ jobs:
           ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
         run: |
           docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app actions run gh-maven-repos restart --kind Deployment --resource-name maven-gh --server argocd.galasa.dev
-          
+      
+      # Wait for the application to show as healthy in ArgoCD
+      - name: Wait for app health in ArgoCD
+        env: 
+          ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+        run: |
+          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app wait gh-maven-repos --resource apps:Deployment:maven-gh --health --server argocd.galasa.dev
+
+  trigger-framework-workflow:
+    name: Trigger Framework workflow
+    runs-on: ubuntu-latest
+    needs: build-maven 
+
+    steps:
+      - name: Trigger Framework workflow dispatch event with GitHub CLI
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          gh workflow run build.yaml --repo https://github.com/galasa-dev/framework


### PR DESCRIPTION
## Why?
For issue https://github.com/galasa-dev/projectmanagement/issues/1950 joining the core build chain together. Using the GH CLI as using GitHub's built in "reusable workflow" concept nests the workflows inside eachother instead of just calling the next once one is done.